### PR TITLE
ITC-222: New view mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "drupal/system_status": "^2.9",
         "drupal/captcha": "^1.1",
         "drupal/hierarchical_taxonomy_menu": "^1.42",
-        "drupal/antibot": "^1.4"
+        "drupal/antibot": "^1.4",
+        "drupal/memcache": "^2.3"
 
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08c94a8f73161b9fb80ebf6496aaaa53",
+    "content-hash": "f1c5cbb50d19a99bdb99b32d3472fcb4",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -294,7 +294,7 @@
             "version": "1.11.15",
             "source": {
                 "type": "git",
-                "url": "git@github.com:jonthornton/jquery-timepicker.git",
+                "url": "https://github.com/jonthornton/jquery-timepicker.git",
                 "reference": "f3c122dbbf0b77642e43a2ea3f6181c9bac2d334"
             },
             "dist": {
@@ -5362,6 +5362,82 @@
             "homepage": "https://www.drupal.org/project/mailsystem",
             "support": {
                 "source": "https://git.drupalcode.org/project/mailsystem"
+            }
+        },
+        {
+            "name": "drupal/memcache",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/memcache.git",
+                "reference": "8.x-2.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/memcache-8.x-2.3.zip",
+                "reference": "8.x-2.3",
+                "shasum": "b2f9715612be74f9ce55daaf838f6f17a9eb2f5a"
+            },
+            "require": {
+                "drupal/core": "^8.9 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.3",
+                    "datestamp": "1614802365",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-8.x-2.x": "2.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabianx",
+                    "homepage": "https://www.drupal.org/user/693738"
+                },
+                {
+                    "name": "Jeremy",
+                    "homepage": "https://www.drupal.org/user/409"
+                },
+                {
+                    "name": "bdragon",
+                    "homepage": "https://www.drupal.org/user/53081"
+                },
+                {
+                    "name": "catch",
+                    "homepage": "https://www.drupal.org/user/35733"
+                },
+                {
+                    "name": "damiankloip",
+                    "homepage": "https://www.drupal.org/user/1037976"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "jvandyk",
+                    "homepage": "https://www.drupal.org/user/2375"
+                },
+                {
+                    "name": "robertDouglass",
+                    "homepage": "https://www.drupal.org/user/5449"
+                }
+            ],
+            "description": "High performance integration with memcache.",
+            "homepage": "http://drupal.org/project/memcache",
+            "support": {
+                "source": "https://git.drupalcode.org/project/memcache",
+                "issues": "https://www.drupal.org/project/issues/memcache"
             }
         },
         {

--- a/config/sync/core.entity_view_display.node.topic.news_page.yml
+++ b/config/sync/core.entity_view_display.node.topic.news_page.yml
@@ -1,60 +1,71 @@
-uuid: 44d33463-3a39-4ae0-8577-f7229e9b2375
+uuid: e21f5304-962f-4ba7-97e2-92ad250a8e97
 langcode: da
 status: true
 dependencies:
   config:
-    - core.entity_view_display.comment.comment.default
+    - core.entity_view_mode.node.news_page
     - field.field.node.topic.body
     - field.field.node.topic.field_content_visibility
     - field.field.node.topic.field_files
     - field.field.node.topic.field_topic_comments
     - field.field.node.topic.field_topic_image
     - field.field.node.topic.field_topic_type
+    - image.style.social_x_large
     - node.type.topic
   module:
-    - file
-    - group_core_comments
+    - image
+    - lazy
+    - options
     - text
     - user
 _core:
   default_config_hash: nklLxWaEksFeM3G1wLFL20XlyjbRZcoDbjtefSxPyRE
-id: node.topic.default
+id: node.topic.news_page
 targetEntityType: node
 bundle: topic
-mode: default
+mode: news_page
 content:
   body:
-    label: hidden
+    label: above
     type: text_default
-    weight: 0
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     region: content
-  field_files:
-    weight: 3
-    label: above
-    settings:
-      use_description_as_link_text: true
-    third_party_settings: {  }
+  field_content_visibility:
+    type: list_default
+    weight: 5
     region: content
-    type: file_default
-  field_topic_comments:
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_topic_image:
+    type: image
     weight: 1
-    label: above
-    settings:
-      pager_id: 0
-      view_mode: default
-    third_party_settings: {  }
     region: content
-    type: comment_group_content
+    label: hidden
+    settings:
+      image_style: social_x_large
+      image_link: content
+    third_party_settings:
+      lazy:
+        lazy_image: 0
+  field_topic_type:
+    type: entity_reference_label
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
   flag_follow_content:
-    weight: 10
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   groups_type_flexible_group:
     label: above
-    weight: -5
+    weight: 0
     region: content
     settings:
       link: true
@@ -66,14 +77,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   links:
-    weight: 6
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_content_visibility: true
-  field_topic_image: true
-  field_topic_type: true
+  field_files: true
+  field_topic_comments: true
   groups: true
   groups_type_closed_group: true
   groups_type_open_group: true

--- a/config/sync/core.entity_view_mode.node.news_page.yml
+++ b/config/sync/core.entity_view_mode.node.news_page.yml
@@ -1,0 +1,10 @@
+uuid: 5e1377b9-5dc1-42b1-9e19-470ddecb0d11
+langcode: da
+status: true
+dependencies:
+  module:
+    - node
+id: node.news_page
+label: 'News page'
+targetEntityType: node
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   link: 0
   locale: 0
   mailsystem: 0
+  memcache: 0
   mentions: 0
   menu_ui: 0
   message: 0

--- a/config/sync/socialblue.settings.yml
+++ b/config/sync/socialblue.settings.yml
@@ -46,3 +46,4 @@ features:
   comment_user_verification: 0
   favicon: 1
   node_user_picture: true
+langcode: da

--- a/config/sync/views.view.news.yml
+++ b/config/sync/views.view.news.yml
@@ -3,7 +3,7 @@ langcode: da
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.news_page
     - node.type.topic
     - system.menu.main
     - taxonomy.vocabulary.topic_types
@@ -41,7 +41,8 @@ display:
           distinct: false
           replica: false
           query_comment: ''
-          query_tags: {  }
+          query_tags:
+            - news_page
       exposed_form:
         type: basic
         options:
@@ -75,7 +76,8 @@ display:
       row:
         type: 'entity:node'
         options:
-          view_mode: teaser
+          relationship: none
+          view_mode: news_page
       fields:
         title:
           id: title
@@ -267,14 +269,14 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  page_1:
+  news:
     display_plugin: page
-    id: page_1
+    id: news
     display_title: Page
     position: 1
     display_options:
       display_extenders: {  }
-      path: Nyheder
+      path: nyheder
       menu:
         type: normal
         title: Nyheder

--- a/config/sync/views.view.social_group_invitations.yml
+++ b/config/sync/views.view.social_group_invitations.yml
@@ -1,5 +1,5 @@
 uuid: 089317e3-ebad-4e75-8c1b-f47ef68e7917
-langcode: en
+langcode: da
 status: true
 dependencies:
   config:

--- a/config/sync/views.view.social_group_user_invitations.yml
+++ b/config/sync/views.view.social_group_user_invitations.yml
@@ -1,5 +1,5 @@
 uuid: 2bc3a56b-fe42-41a3-bbc8-43cec594ddc8
-langcode: en
+langcode: da
 status: true
 dependencies:
   module:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,0 +1,71 @@
+# itk-version: 1.0.0
+version: "3"
+
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+
+services:
+  phpfpm:
+    image: itkdev/php7.4-fpm:alpine
+    restart: unless-stopped
+    networks:
+      - app
+    environment:
+      - PHP_MAX_EXECUTION_TIME=30
+      - PHP_MEMORY_LIMIT=128M
+      - COMPOSER_VERSION=1
+    depends_on:
+      - memcached
+    volumes:
+      - .:/app:delegated
+      - drush-cache:/root/.drush
+
+  nginx:
+    image: nginx:stable-alpine
+    restart: unless-stopped
+    networks:
+      - app
+      - frontend
+    depends_on:
+      - phpfpm
+    ports:
+      - '80'
+    volumes:
+      - ${PWD}/.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./:/app:rw
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-http.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-http.entrypoints=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-http.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"     
+       #- "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=ITKBasicAuth@file"
+
+  memcached:
+    image: 'memcached:latest'
+    restart: unless-stopped
+    networks:
+      - app
+    environment:
+      - MEMCACHED_CACHE_SIZE=64
+
+  drush:
+    image: itkdev/drush6:latest
+    networks:
+      - app
+    entrypoint:
+      - drush
+    volumes:
+      - drush-cache:/root/.drush
+      - ./:/app
+
+# Drush cache volume to persist cache between runs.
+volumes:
+  drush-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# itk-version: 1.0.0
 version: "3"
 
 networks:
@@ -22,24 +23,23 @@ services:
       - MYSQL_PASSWORD=db
       - MYSQL_DATABASE=db
       #- ENCRYPT=1 # Uncomment to enable database encryption.
-    # @see https://symfony.com/doc/current/setup/symfony_server.html#docker-integration
-    labels:
-      com.symfony.server.service-prefix: 'DATABASE'
 
   phpfpm:
     image: itkdev/php7.4-fpm:latest
     networks:
       - app
     environment:
-      - PHP_XDEBUG=${PHP_XDEBUG:-0}
-      - PHP_XDEBUG_REMOTE_AUTOSTART=${PHP_XDEBUG_REMOTE_AUTOSTART:-0}
-      - PHP_XDEBUG_REMOTE_CONNECT_BACK=${PHP_XDEBUG_REMOTE_CONNECT_BACK:-0}
-      - PHP_MAX_EXECUTION_TIME=120
+      - XDEBUG_MODE=${XDEBUG_MODE:-off}
+      - XDEBUG_SESSION=${XDEBUG_SESSION:-0}
+      - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=256M
       # - PHP_MAIL=1 # Uncomment to enable mailhog.
+      - PHP_IDE_CONFIG=serverName=localhost
       - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
+      - COMPOSER_VERSION=1
     depends_on:
       - mariadb
+      - memcached
     volumes:
       - .:/app:delegated
       - drush-cache:/root/.drush
@@ -51,7 +51,6 @@ services:
       - frontend
     depends_on:
       - phpfpm
-      - memcached
     ports:
       - '80'
     volumes:

--- a/html/sites/default/_docker.settings.local.php
+++ b/html/sites/default/_docker.settings.local.php
@@ -51,3 +51,8 @@ $settings['trusted_host_patterns'] = [
   '^127\.0\.0\.1$',
   '^itchefer\.local\.itkdev\.dk$',
 ];
+
+$settings['memcache']['servers'] = ['memcached:11211' => 'default'];
+$settings['memcache']['bins'] = ['default' => 'default'];
+$settings['memcache']['key_prefix'] = 'itchefer';
+$settings['cache']['default'] = 'cache.backend.memcache';

--- a/html/sites/default/services.test.yml
+++ b/html/sites/default/services.test.yml
@@ -1,0 +1,4 @@
+parameters:
+   twig.config:
+    debug: true
+    cache: true

--- a/html/sites/default/services.test.yml
+++ b/html/sites/default/services.test.yml
@@ -1,4 +1,4 @@
 parameters:
    twig.config:
     debug: true
-    cache: true
+    cache: false

--- a/html/sites/default/services.test.yml
+++ b/html/sites/default/services.test.yml
@@ -1,4 +1,0 @@
-parameters:
-   twig.config:
-    debug: true
-    cache: false

--- a/html/themes/custom/itchefer/templates/node/node--teaser.html.twig
+++ b/html/themes/custom/itchefer/templates/node/node--teaser.html.twig
@@ -74,6 +74,7 @@
     'teaser',
     'teaser-' ~ node.bundle|clean_class,
     view_mode == 'teaser' ? 'card',
+    view_mode == 'news_page' ? 'card',
     view_mode == 'activity' ? 'teaser--stream',
     view_mode == 'activity_comment' ? 'teaser--stream',
     node.isPromoted() ? 'promoted',
@@ -92,7 +93,7 @@
 
   <div class='teaser__image' aria-hidden="true">
 
-    {% if view_mode == 'teaser' or no_image %}
+    {% if view_mode == 'teaser' or view_mode == 'news_page' or no_image %}
       {% block card_teaser_type %}
         <a href="{{ url }}" title="{{- node.bundle|clean_class|capitalize -}} : &nbsp; {{- label|render|striptags|trim -}}">
           <div class="teaser__teaser-type">

--- a/html/themes/custom/itchefer/templates/node/topic/field--node--body--topic.html.twig
+++ b/html/themes/custom/itchefer/templates/node/topic/field--node--body--topic.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content|render|striptags }}
+{% endfor %}

--- a/html/themes/custom/itchefer/templates/node/topic/node--topic--activity-comment.html.twig
+++ b/html/themes/custom/itchefer/templates/node/topic/node--topic--activity-comment.html.twig
@@ -1,1 +1,1 @@
-{% extends "node--topic--teaser.html.twig" %}
+{% extends "node--topic--news-page.html.twig" %}

--- a/html/themes/custom/itchefer/templates/node/topic/node--topic--activity.html.twig
+++ b/html/themes/custom/itchefer/templates/node/topic/node--topic--activity.html.twig
@@ -1,1 +1,1 @@
-{% extends "node--topic--teaser.html.twig" %}
+{% extends "node--topic--news-page.html.twig" %}

--- a/html/themes/custom/itchefer/templates/node/topic/node--topic--news-page.html.twig
+++ b/html/themes/custom/itchefer/templates/node/topic/node--topic--news-page.html.twig
@@ -1,3 +1,6 @@
+{# // This is an evil hack to change some stuff from the base theme #}
+{% set part_of_teaser = true %}
+
 {% extends "node--teaser.html.twig" %}
 
 {% block card_body %}
@@ -8,13 +11,9 @@
       <div class="teaser__published">
         <div class="teaser__published-date"> {{ date }} &bullet; </div>
         <div class="teaser__published-author"> {{ author_name }} </div>
-
       </div>
-   
     {%- endblock -%}
   {% endembed %}
-
-
 
   {% if content.group_name %}
     {% embed "node--teaser__field.html.twig" %}

--- a/html/themes/custom/itchefer/templates/node/topic/node--topic--news-page.html.twig
+++ b/html/themes/custom/itchefer/templates/node/topic/node--topic--news-page.html.twig
@@ -1,6 +1,3 @@
-{# // This is an evil hack to change some stuff from the base theme #}
-{% set part_of_teaser = true %}
-
 {% extends "node--teaser.html.twig" %}
 
 {% block card_body %}


### PR DESCRIPTION
The twig cache between, front page and "/nyheder" view list uses the samme view content and the same display mode, which makes the clash in the cache.

This introduces a new view mode for the "/nyheder" page so they are render in different templates etc.

Also added memcache to get cache out of the database (need after many cache clear).